### PR TITLE
Add options argument

### DIFF
--- a/documentation/fundamentals/readme.md
+++ b/documentation/fundamentals/readme.md
@@ -9,7 +9,8 @@ local frame = path.to.frame
 
 Text.Create(
 	frame, -- Parent and boundary.
-	"This text is awesome!" -- Text.
+	"This text is awesome!", -- Text.
+	{} -- Options.
 )
 ```
 


### PR DESCRIPTION
Otherwise it will cause an error

TextPlus:1777
-- Exit because we have no options to work with.
error("Invalid options.", 2)